### PR TITLE
Validation check for unwrapped up voice tasks

### DIFF
--- a/src/components/dialpad/DialPad.js
+++ b/src/components/dialpad/DialPad.js
@@ -352,11 +352,26 @@ export class DialPad extends React.Component {
     })
   }
 
+  checkNoVoiceTasksOpen() {
+    const { tasks } = this.props;
+
+    var response = true;
+    tasks.forEach(value => {
+      console.log(value);
+      if (value.channelType === "voice") {
+        response = false;
+      }
+    })
+
+    return response;
+  };
+
   dial() {
     console.log("ATTEMPTING TO DIAL");
     console.log("Number: ", this.props.number);
     console.log("callStatus: ", this.props.call.callStatus);
     if (
+      this.checkNoVoiceTasksOpen() &&
       this.props.number !== "" &&
       (!this.props.call || this.props.call.callStatus === "" || this.props.call.callStatus === "completed" || this.props.call.callStatus === "canceled") &&
       this.props.activeCall === ""
@@ -587,6 +602,7 @@ export class DialPad extends React.Component {
 
 const mapStateToProps = state => {
   return {
+    tasks: state.flex.worker.tasks,
     phoneNumber: state.flex.worker.attributes.phone,
     workerContactUri: state.flex.worker.attributes.contact_uri,
     activeCall:

--- a/src/notifications/CustomNotifications.js
+++ b/src/notifications/CustomNotifications.js
@@ -34,7 +34,7 @@ if (!manager.strings.activityStateUnavailable) {
 }
 
 if (!manager.strings.cantDialOut) {
-  manager.strings.cantDialOut = "You cannot make a call while active with another call";
+  manager.strings.cantDialOut = "You cannot make a call while active with another call, please make sure any voice tasks have been wrapped up";
 
   Notifications.registerNotification({
     id: "CantDialOut",


### PR DESCRIPTION
Adding in check before dialing that there are no voice tasks at all, voice tasks in wrapup can block incoming voice tasks

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.
